### PR TITLE
Inliner section safety

### DIFF
--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -442,7 +442,7 @@ def : CompatRule<"isEqual<UseSampleProfileAttr>">;
 def : CompatRule<"isEqual<NoProfileAttr>">;
 def : CompatRule<"checkDenormMode">;
 def : CompatRule<"checkStrictFP">;
-def : CompatRule<"checkSections">;
+def : CompatRule<"checkSectionsMSVC">;
 def : CompatRuleStrAttr<"isEqual", "sign-return-address">;
 def : CompatRuleStrAttr<"isEqual", "sign-return-address-key">;
 def : CompatRuleStrAttr<"isEqual", "branch-protection-pauth-lr">;

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -442,6 +442,7 @@ def : CompatRule<"isEqual<UseSampleProfileAttr>">;
 def : CompatRule<"isEqual<NoProfileAttr>">;
 def : CompatRule<"checkDenormMode">;
 def : CompatRule<"checkStrictFP">;
+def : CompatRule<"checkSections">;
 def : CompatRuleStrAttr<"isEqual", "sign-return-address">;
 def : CompatRuleStrAttr<"isEqual", "sign-return-address-key">;
 def : CompatRuleStrAttr<"isEqual", "branch-protection-pauth-lr">;

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -2507,7 +2507,10 @@ static bool checkStrictFP(const Function &Caller, const Function &Callee) {
          Caller.getAttributes().hasFnAttr(Attribute::StrictFP);
 }
 
-static bool checkSections(const Function &Caller, const Function &Callee) {
+static bool checkSectionsMSVC(const Function &Caller, const Function &Callee) {
+  if (!Caller.getParent()->getTargetTriple().isWindowsMSVCEnvironment())
+    return true;
+
   // Implement MSVC compatible cross-section inlining rules
   StringRef CallerSection = Caller.getSection();
   StringRef CalleeSection = Callee.getSection();

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -2507,6 +2507,44 @@ static bool checkStrictFP(const Function &Caller, const Function &Callee) {
          Caller.getAttributes().hasFnAttr(Attribute::StrictFP);
 }
 
+static bool checkSections(const Function &Caller, const Function &Callee) {
+  // Implement MSVC compatible cross-section inlining rules
+  StringRef CallerSection = Caller.getSection();
+  StringRef CalleeSection = Callee.getSection();
+
+  // sections match, inline ok
+  if (!CallerSection.compare(CalleeSection))
+    return true;
+
+  bool isCallerPaged = CallerSection.starts_with("PAGE");
+  bool isCalleePaged = CalleeSection.starts_with("PAGE");
+
+  // Prevent inlining of non-paged code into a paged caller
+  // Prevent inlining of paged code into non-paged caller
+  // Section names are compared only before the '$' separator if present
+
+  if (isCallerPaged) {
+    size_t CallerComparable = CallerSection.size();
+    size_t CalleeComparable = CalleeSection.size();
+    size_t CallerSep = CallerSection.find('$');
+    size_t CalleeSep = CalleeSection.find('$');
+
+    if (CallerSep != StringRef::npos)
+      CallerComparable = CallerSep;
+    if (CalleeSep != StringRef::npos)
+      CalleeComparable = CalleeSep;
+    if (CallerComparable != CalleeComparable)
+      return false;
+
+    StringRef CallerComparableSection = CallerSection.substr(0, CallerComparable);
+    StringRef CalleeComparableSection = CalleeSection.substr(0, CallerComparable);
+    return !CallerComparableSection.compare(CalleeComparableSection);
+  } else if (isCalleePaged)
+    return false;
+
+  return true;
+}
+
 template<typename AttrClass>
 static bool isEqual(const Function &Caller, const Function &Callee) {
   return Caller.getFnAttribute(AttrClass::getKind()) ==

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -2539,8 +2539,10 @@ static bool checkSectionsMSVC(const Function &Caller, const Function &Callee) {
     if (CallerComparable != CalleeComparable)
       return false;
 
-    StringRef CallerComparableSection = CallerSection.substr(0, CallerComparable);
-    StringRef CalleeComparableSection = CalleeSection.substr(0, CallerComparable);
+    StringRef CallerComparableSection =
+        CallerSection.substr(0, CallerComparable);
+    StringRef CalleeComparableSection =
+        CalleeSection.substr(0, CallerComparable);
     return !CallerComparableSection.compare(CalleeComparableSection);
   } else if (isCalleePaged)
     return false;

--- a/llvm/test/Transforms/Inline/inline-msvc-sections.ll
+++ b/llvm/test/Transforms/Inline/inline-msvc-sections.ll
@@ -1,5 +1,7 @@
 ; RUN: opt < %s -passes=inline -inline-threshold=100 -S | FileCheck %s
-; RUN: opt < %s -mtriple=aarch64-windows-msvc -passes=inline -inline-threshold=100 -S | FileCheck %s
+; RUN: opt < %s -passes='cgscc(inline)' -inline-threshold=100 -S | FileCheck %s
+; RUN: opt < %s -mtriple=aarch64-windows-msvc -passes=inline -inline-threshold=100 -S | FileCheck %s -check-prefix=MSVC
+; RUN: opt < %s -mtriple=aarch64-windows-msvc -passes='cgscc(inline)' -inline-threshold=100 -S | FileCheck %s -check-prefix=MSVC
 
 define i32 @nosection_callee(i32 %x) {
   %x1 = add i32 %x, 1
@@ -50,6 +52,19 @@ define i32 @nosection_caller(i32 %y1) {
   ret i32 %y6
 }
   
+; CHECK-LABEL: @nosection_caller
+; CHECK-NOT: @nosection_callee
+; CHECK-NOT: @section_callee
+; CHECK-NOT: @sectionpostfix_callee
+; CHECK-NOT: @paged_callee
+; CHECK-NOT: @pagedpostfix_callee
+; MSVC-LABEL: @nosection_caller
+; MSVC-NOT: @nosection_callee
+; MSVC-NOT: @section_callee
+; MSVC-NOT: @sectionpostfix_callee
+; MSVC: @paged_callee
+; MSVC: @pagedpostfix_callee
+
 define i32 @section_caller(i32 %y1) section "FOO" {
   %y2 = call i32 @nosection_callee(i32 %y1)
   %y3 = call i32 @section_callee(i32 %y2)
@@ -58,6 +73,19 @@ define i32 @section_caller(i32 %y1) section "FOO" {
   %y6 = call i32 @pagedpostfix_callee(i32 %y5)
   ret i32 %y6
 }
+
+; CHECK-LABEL: @section_caller
+; CHECK-NOT: @nosection_callee
+; CHECK-NOT: @section_callee
+; CHECK-NOT: @sectionpostfix_callee
+; CHECK-NOT: @paged_callee
+; CHECK-NOT: @pagedpostfix_callee
+; MSVC-LABEL: @section_caller
+; MSVC-NOT: @nosection_callee
+; MSVC-NOT: @section_callee
+; MSVC-NOT: @sectionpostfix_callee
+; MSVC: @paged_callee
+; MSVC: @pagedpostfix_callee
 
 define i32 @sectionpostfix_caller(i32 %y1) section "FOO$ZZZ" {
   %y2 = call i32 @nosection_callee(i32 %y1)
@@ -68,6 +96,19 @@ define i32 @sectionpostfix_caller(i32 %y1) section "FOO$ZZZ" {
   ret i32 %y6
 }
 
+; CHECK-LABEL: @sectionpostfix_caller
+; CHECK-NOT: @nosection_callee
+; CHECK-NOT: @section_callee
+; CHECK-NOT: @sectionpostfix_callee
+; CHECK-NOT: @paged_callee
+; CHECK-NOT: @pagedpostfix_callee
+; MSVC-LABEL: @sectionpostfix_caller
+; MSVC-NOT: @nosection_callee
+; MSVC-NOT: @section_callee
+; MSVC-NOT: @sectionpostfix_callee
+; MSVC: @paged_callee
+; MSVC: @pagedpostfix_callee
+
 define i32 @paged_caller(i32 %y1) section "PAGE" {
   %y2 = call i32 @nosection_callee(i32 %y1)
   %y3 = call i32 @section_callee(i32 %y2)
@@ -76,6 +117,19 @@ define i32 @paged_caller(i32 %y1) section "PAGE" {
   %y6 = call i32 @pagedpostfix_callee(i32 %y5)
   ret i32 %y6
 }
+
+; CHECK-LABEL: @paged_caller
+; CHECK-NOT: @nosection_callee
+; CHECK-NOT: @section_callee
+; CHECK-NOT: @sectionpostfix_callee
+; CHECK-NOT: @paged_callee
+; CHECK-NOT: @pagedpostfix_callee
+; MSVC-LABEL: @paged_caller
+; MSVC: @nosection_callee
+; MSVC: @section_callee
+; MSVC: @sectionpostfix_callee
+; MSVC-NOT: @paged_callee
+; MSVC-NOT: @pagedpostfix_callee
 
 define i32 @pagedpostfix_caller(i32 %y1) section "PAGE$ZZZ" {
   %y2 = call i32 @nosection_callee(i32 %y1)
@@ -86,7 +140,18 @@ define i32 @pagedpostfix_caller(i32 %y1) section "PAGE$ZZZ" {
   ret i32 %y6
 }
 
+; CHECK-LABEL: @pagedpostfix_caller
+; CHECK-NOT: @nosection_callee
+; CHECK-NOT: @section_callee
+; CHECK-NOT: @sectionpostfix_callee
+; CHECK-NOT: @paged_callee
+; CHECK-NOT: @pagedpostfix_callee
+; MSVC-LABEL: @pagedpostfix_caller
+; MSVC: @nosection_callee
+; MSVC: @section_callee
+; MSVC: @sectionpostfix_callee
+; MSVC-NOT: @paged_callee
+; MSVC-NOT: @pagedpostfix_callee
 
 declare void @extern()
 
-; CHECK-LABEL: @paged_callee

--- a/llvm/test/Transforms/Inline/inline-msvc-sections.ll
+++ b/llvm/test/Transforms/Inline/inline-msvc-sections.ll
@@ -1,0 +1,92 @@
+; RUN: opt < %s -passes=inline -inline-threshold=100 -S | FileCheck %s
+; RUN: opt < %s -mtriple=aarch64-windows-msvc -passes=inline -inline-threshold=100 -S | FileCheck %s
+
+define i32 @nosection_callee(i32 %x) {
+  %x1 = add i32 %x, 1
+  %x2 = add i32 %x1, 1
+  %x3 = add i32 %x2, 1
+  call void @extern()
+  ret i32 %x3
+}
+
+define i32 @section_callee(i32 %x) section "FOO" {
+  %x1 = add i32 %x, 1
+  %x2 = add i32 %x1, 1
+  %x3 = add i32 %x2, 1
+  call void @extern()
+  ret i32 %x3
+}
+
+define i32 @sectionpostfix_callee(i32 %x) section "FOO$BBBB" {
+  %x1 = add i32 %x, 1
+  %x2 = add i32 %x1, 1
+  %x3 = add i32 %x2, 1
+  call void @extern()
+  ret i32 %x3
+}
+
+define i32 @paged_callee(i32 %x) section "PAGE" {
+  %x1 = add i32 %x, 1
+  %x2 = add i32 %x1, 1
+  %x3 = add i32 %x2, 1
+  call void @extern()
+  ret i32 %x3
+}
+
+define i32 @pagedpostfix_callee(i32 %x) section "PAGE$aaa" {
+  %x1 = add i32 %x, 1
+  %x2 = add i32 %x1, 1
+  %x3 = add i32 %x2, 1
+  call void @extern()
+  ret i32 %x3
+}
+
+define i32 @nosection_caller(i32 %y1) {
+  %y2 = call i32 @nosection_callee(i32 %y1)
+  %y3 = call i32 @section_callee(i32 %y2)
+  %y4 = call i32 @sectionpostfix_callee(i32 %y3)
+  %y5 = call i32 @paged_callee(i32 %y4)
+  %y6 = call i32 @pagedpostfix_callee(i32 %y5)
+  ret i32 %y6
+}
+  
+define i32 @section_caller(i32 %y1) section "FOO" {
+  %y2 = call i32 @nosection_callee(i32 %y1)
+  %y3 = call i32 @section_callee(i32 %y2)
+  %y4 = call i32 @sectionpostfix_callee(i32 %y3)
+  %y5 = call i32 @paged_callee(i32 %y4)
+  %y6 = call i32 @pagedpostfix_callee(i32 %y5)
+  ret i32 %y6
+}
+
+define i32 @sectionpostfix_caller(i32 %y1) section "FOO$ZZZ" {
+  %y2 = call i32 @nosection_callee(i32 %y1)
+  %y3 = call i32 @section_callee(i32 %y2)
+  %y4 = call i32 @sectionpostfix_callee(i32 %y3)
+  %y5 = call i32 @paged_callee(i32 %y4)
+  %y6 = call i32 @pagedpostfix_callee(i32 %y5)
+  ret i32 %y6
+}
+
+define i32 @paged_caller(i32 %y1) section "PAGE" {
+  %y2 = call i32 @nosection_callee(i32 %y1)
+  %y3 = call i32 @section_callee(i32 %y2)
+  %y4 = call i32 @sectionpostfix_callee(i32 %y3)
+  %y5 = call i32 @paged_callee(i32 %y4)
+  %y6 = call i32 @pagedpostfix_callee(i32 %y5)
+  ret i32 %y6
+}
+
+define i32 @pagedpostfix_caller(i32 %y1) section "PAGE$ZZZ" {
+  %y2 = call i32 @nosection_callee(i32 %y1)
+  %y3 = call i32 @section_callee(i32 %y2)
+  %y4 = call i32 @sectionpostfix_callee(i32 %y3)
+  %y5 = call i32 @paged_callee(i32 %y4)
+  %y6 = call i32 @pagedpostfix_callee(i32 %y5)
+  ret i32 %y6
+}
+
+
+declare void @extern()
+
+; CHECK-LABEL: @paged_callee


### PR DESCRIPTION
Alter LLVM behavior so that in MSVC environment, it follows MSVC inlining rules.

<a comment is missing that will have to lay out those rules>

Currently there is no switch to enable/disable this functionality and it should operate for Rust as well.